### PR TITLE
Create initial CMS foundation with admin management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/vendor/
+/storage/*.sqlite
+/storage/version_cache*
+/storage/*.log

--- a/README.md
+++ b/README.md
@@ -1,2 +1,65 @@
-# Dragon-Reptiles-CMS
-Dragon-Reptiles-CMS
+# Dragon Reptiles CMS
+
+Ein leichtgewichtiges, zukunftsorientiertes CMS für Wissensaufbereitung rund um Reptilienarten wie *Pogona vitticeps*, *Heloderma suspectum* und viele mehr. Das System kombiniert ein modernes Headless-inspiriertes UI mit einer schnellen SQLite-Datenbasis und legt den Fokus auf Erweiterbarkeit für Haltungsguides, Tierbestandsverwaltung, Genetik-Tools und weitere kommende Module.
+
+## Features
+
+- 🚀 **Moderne Administrationsoberfläche** auf Tailwind-Basis mit Darkmode-Design.
+- 🧭 **Flexible Seitengestaltung** inkl. Startseite, individuellen Seiten und frei editierbarem HTML-Inhalt.
+- 📰 **News-/Blog-System** mit Entwurfs- und Veröffentlichungsfunktion.
+- 👥 **Nutzerverwaltung** für Administratoren und Redakteure mit sicherer Passwort-Hashing-Strategie (Argon2id).
+- 🛠️ **Branding- & Layout-Settings** (Logo, Header, Footer, Sidebar, Menüstruktur) direkt im Adminbereich editierbar.
+- 🪄 **Automatisches Setup** mit SQLite, inklusive Migrationen und Initialdaten.
+- 📈 **Versionstracking**: Versionsnummer wird im Footer angezeigt und basiert auf der in der Datenbank gepflegten Release-Historie.
+
+## Systemvoraussetzungen
+
+- PHP 8.2 oder höher (entwickelt und getestet mit PHP 8.2+)
+- SQLite3 (in PHP integriert)
+- Optional: Eingebauter PHP-Webserver für lokale Entwicklung
+
+## Installation & Start
+
+1. Repository klonen oder entpacken.
+2. Abhängigkeiten sind nicht erforderlich – es wird kein Composer benötigt.
+3. Einen Webserver auf das `public/`-Verzeichnis zeigen lassen, z. B. lokal:
+   ```bash
+   php -S 0.0.0.0:8000 -t public
+   ```
+4. Beim ersten Aufruf wird automatisch die SQLite-Datenbank `storage/database.sqlite` erzeugt und migriert.
+
+## Admin-Zugang
+
+- URL: `/admin/login.php`
+- Standard-Zugangsdaten:
+  - **E-Mail:** `admin@example.com`
+  - **Passwort:** `ChangeMe123!`
+- Bitte nach dem ersten Login sofort über die Benutzerverwaltung ändern.
+
+## Versionierung
+
+Die Versionsnummer wird aus der Tabelle `version_history` ermittelt und im Footer angezeigt. Neue Releases sollten über die `VersionManager::record()`-Methode gepflegt werden (z. B. in neuen Migrationen oder Setup-Skripten), damit Erweiterungen/Fixes automatisch die Versionsnummer erhöhen.
+
+## Tests
+
+Nach Codeänderungen sollte folgendes Linting ausgeführt werden:
+
+```bash
+find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l
+```
+
+## Feature-Checkliste
+
+- [x] Administrationsbereich mit moderner UI und Login
+- [x] Einstellungsmodul für Logo, Header, Footer, Sidebar und Menüstruktur
+- [x] Seitenverwaltung inklusive Startseiten-Definition
+- [x] News/Blog-Verwaltung mit Veröffentlichungsoption
+- [x] Benutzerverwaltung mit Rollen (Admin, Editor)
+- [ ] Module für Tierbestandsverwaltung
+- [ ] Tierabgabe- & Tierprofil-Module
+- [ ] Genetik-Rechner & Zuchtplanung
+- [ ] Haltungsguides & Genetik-Guides
+
+## Lizenz
+
+Projektspezifische Lizenzierung – bitte bei Bedarf ergänzen.

--- a/admin/auth.php
+++ b/admin/auth.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../bootstrap.php';
+
+use App\Services\AuthService;
+
+$auth = AuthService::make();
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: /admin/login.php');
+    exit;
+}
+
+$currentUser = $auth->user();

--- a/admin/index.php
+++ b/admin/index.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/auth.php';
+
+use App\Core\View;
+use App\Repositories\PageRepository;
+use App\Repositories\PostRepository;
+use App\Repositories\SettingRepository;
+
+$settings = SettingRepository::make()->all();
+$pages = PageRepository::make()->all();
+$posts = PostRepository::make()->all();
+
+$navigation = [
+    ['label' => 'Übersicht', 'href' => '/admin/index.php', 'active' => true],
+    ['label' => 'Einstellungen', 'href' => '/admin/settings.php', 'active' => false],
+    ['label' => 'Seiten', 'href' => '/admin/pages.php', 'active' => false],
+    ['label' => 'News', 'href' => '/admin/posts.php', 'active' => false],
+    ['label' => 'User', 'href' => '/admin/users.php', 'active' => false],
+];
+
+ob_start();
+?>
+<section class="grid gap-6 md:grid-cols-3">
+    <div class="rounded-2xl border border-slate-800 bg-slate-900/40 p-6">
+        <p class="text-sm text-slate-400">Seiten</p>
+        <p class="text-3xl font-semibold text-cyan-300"><?= count($pages); ?></p>
+    </div>
+    <div class="rounded-2xl border border-slate-800 bg-slate-900/40 p-6">
+        <p class="text-sm text-slate-400">News Beiträge</p>
+        <p class="text-3xl font-semibold text-cyan-300"><?= count($posts); ?></p>
+    </div>
+    <div class="rounded-2xl border border-slate-800 bg-slate-900/40 p-6">
+        <p class="text-sm text-slate-400">Aktive Version</p>
+        <p class="text-3xl font-semibold text-cyan-300"><?= \App\Services\VersionManager::latest(); ?></p>
+    </div>
+</section>
+<section class="grid gap-6 md:grid-cols-2">
+    <div class="rounded-2xl border border-slate-800 bg-slate-900/50 p-6">
+        <h3 class="text-lg font-semibold text-slate-200 mb-4">Letzte Seiten</h3>
+        <ul class="space-y-2 text-sm text-slate-300">
+            <?php foreach (array_slice($pages, 0, 5) as $page): ?>
+                <li class="flex justify-between"><span><?= htmlspecialchars($page['title']); ?></span><span class="text-slate-500"><?= (new DateTimeImmutable($page['updated_at']))->format('d.m.Y'); ?></span></li>
+            <?php endforeach; ?>
+        </ul>
+    </div>
+    <div class="rounded-2xl border border-slate-800 bg-slate-900/50 p-6">
+        <h3 class="text-lg font-semibold text-slate-200 mb-4">Letzte News</h3>
+        <ul class="space-y-2 text-sm text-slate-300">
+            <?php foreach (array_slice($posts, 0, 5) as $post): ?>
+                <li class="flex justify-between"><span><?= htmlspecialchars($post['title']); ?></span><span class="text-slate-500"><?= (new DateTimeImmutable($post['updated_at']))->format('d.m.Y'); ?></span></li>
+            <?php endforeach; ?>
+        </ul>
+    </div>
+</section>
+<?php
+$content = ob_get_clean();
+
+View::render('admin_layout', [
+    'settings' => $settings,
+    'navigation' => $navigation,
+    'title' => 'Übersicht',
+    'subtitle' => 'Willkommen zurück, ' . htmlspecialchars($currentUser['name'] ?? 'Admin'),
+    'content' => $content,
+]);

--- a/admin/login.php
+++ b/admin/login.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../bootstrap.php';
+
+use App\Repositories\SettingRepository;
+use App\Services\AuthService;
+
+$settings = SettingRepository::make()->all();
+$auth = AuthService::make();
+$error = null;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $email = trim($_POST['email'] ?? '');
+    $password = $_POST['password'] ?? '';
+
+    if ($auth->attempt($email, $password)) {
+        header('Location: /admin/index.php');
+        exit;
+    }
+
+    $error = 'Login fehlgeschlagen. Bitte Zugangsdaten prüfen.';
+}
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Login · <?= htmlspecialchars($settings['site_title'] ?? 'Dragon Reptiles CMS'); ?></title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;600&display=swap" rel="stylesheet">
+    <style>
+        body { font-family: 'Space Grotesk', sans-serif; background: radial-gradient(circle at top, rgba(14,165,233,0.12), #020617 55%); }
+    </style>
+</head>
+<body class="min-h-screen flex items-center justify-center">
+    <div class="w-full max-w-md p-8 rounded-3xl bg-slate-900/80 backdrop-blur border border-slate-800">
+        <h1 class="text-2xl font-semibold text-cyan-300 mb-2">Dragon Reptiles CMS</h1>
+        <p class="text-sm text-slate-400 mb-6">Admin Login</p>
+        <?php if ($error): ?>
+            <div class="mb-4 rounded-lg border border-rose-500/60 bg-rose-500/10 px-4 py-3 text-sm text-rose-200">
+                <?= htmlspecialchars($error); ?>
+            </div>
+        <?php endif; ?>
+        <form method="post" class="space-y-4">
+            <div>
+                <label class="block text-sm text-slate-300 mb-1" for="email">E-Mail</label>
+                <input class="w-full rounded-xl border border-slate-700 bg-slate-800/80 px-4 py-3 text-sm focus:border-cyan-400 focus:outline-none" type="email" name="email" id="email" required>
+            </div>
+            <div>
+                <label class="block text-sm text-slate-300 mb-1" for="password">Passwort</label>
+                <input class="w-full rounded-xl border border-slate-700 bg-slate-800/80 px-4 py-3 text-sm focus:border-cyan-400 focus:outline-none" type="password" name="password" id="password" required>
+            </div>
+            <button class="w-full rounded-xl bg-gradient-to-r from-cyan-500 to-indigo-500 py-3 text-sm font-semibold text-slate-950 hover:from-cyan-400 hover:to-indigo-400" type="submit">Anmelden</button>
+        </form>
+        <p class="text-xs text-slate-500 mt-6">Standardzugang: admin@example.com · ChangeMe123!</p>
+    </div>
+</body>
+</html>

--- a/admin/logout.php
+++ b/admin/logout.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../bootstrap.php';
+
+session_destroy();
+
+header('Location: /admin/login.php');
+exit;

--- a/admin/page_edit.php
+++ b/admin/page_edit.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/auth.php';
+
+use App\Core\Str;
+use App\Core\View;
+use App\Repositories\PageRepository;
+use App\Repositories\SettingRepository;
+
+$pageRepository = PageRepository::make();
+$settings = SettingRepository::make()->all();
+
+$id = isset($_GET['id']) ? (int) $_GET['id'] : null;
+$page = $id ? $pageRepository->find($id) : null;
+
+if ($id && !$page) {
+    http_response_code(404);
+    echo 'Seite nicht gefunden';
+    exit;
+}
+
+$error = null;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $title = trim($_POST['title'] ?? '');
+    $slug = trim($_POST['slug'] ?? '') ?: Str::slug($title);
+    $content = $_POST['content'] ?? '';
+    $isHome = isset($_POST['is_home']) ? 1 : 0;
+
+    if ($title === '' || $content === '') {
+        $error = 'Titel und Inhalt sind erforderlich.';
+    } else {
+        $payload = [
+            'title' => $title,
+            'slug' => Str::slug($slug),
+            'content' => $content,
+            'is_home' => $isHome,
+        ];
+
+        if ($page) {
+            $payload['id'] = $page['id'];
+        }
+
+        $pageRepository->save($payload);
+        header('Location: /admin/pages.php');
+        exit;
+    }
+}
+
+$navigation = [
+    ['label' => 'Übersicht', 'href' => '/admin/index.php', 'active' => false],
+    ['label' => 'Einstellungen', 'href' => '/admin/settings.php', 'active' => false],
+    ['label' => 'Seiten', 'href' => '/admin/pages.php', 'active' => true],
+    ['label' => 'News', 'href' => '/admin/posts.php', 'active' => false],
+    ['label' => 'User', 'href' => '/admin/users.php', 'active' => false],
+];
+
+$pageData = $page ?? ['title' => '', 'slug' => '', 'content' => '', 'is_home' => 0];
+
+ob_start();
+?>
+<?php if ($error): ?>
+    <div class="rounded-xl border border-rose-500/60 bg-rose-500/10 px-4 py-3 text-sm text-rose-200 mb-4">
+        <?= htmlspecialchars($error); ?>
+    </div>
+<?php endif; ?>
+<form method="post" class="space-y-6">
+    <div class="grid gap-6 md:grid-cols-2">
+        <label class="flex flex-col gap-2 text-sm">
+            <span class="text-slate-300">Titel</span>
+            <input class="rounded-xl border border-slate-700 bg-slate-900/60 px-4 py-3" type="text" name="title" value="<?= htmlspecialchars($pageData['title']); ?>" required>
+        </label>
+        <label class="flex flex-col gap-2 text-sm">
+            <span class="text-slate-300">Slug</span>
+            <input class="rounded-xl border border-slate-700 bg-slate-900/60 px-4 py-3" type="text" name="slug" value="<?= htmlspecialchars($pageData['slug']); ?>">
+        </label>
+    </div>
+    <label class="inline-flex items-center gap-2 text-sm text-slate-300">
+        <input type="checkbox" name="is_home" value="1" <?= (int) $pageData['is_home'] === 1 ? 'checked' : ''; ?>>
+        Als Startseite verwenden
+    </label>
+    <label class="flex flex-col gap-2 text-sm">
+        <span class="text-slate-300">Inhalt (HTML)</span>
+        <textarea class="rounded-xl border border-slate-700 bg-slate-900/60 px-4 py-3 h-80" name="content" required><?= htmlspecialchars($pageData['content']); ?></textarea>
+    </label>
+    <div class="flex justify-end gap-3">
+        <a class="px-5 py-3 rounded-xl border border-slate-700 hover:border-slate-500" href="/admin/pages.php">Abbrechen</a>
+        <button class="rounded-xl bg-gradient-to-r from-cyan-500 to-indigo-500 px-6 py-3 text-sm font-semibold text-slate-950 hover:from-cyan-400 hover:to-indigo-400" type="submit">Speichern</button>
+    </div>
+</form>
+<?php
+$content = ob_get_clean();
+
+View::render('admin_layout', [
+    'settings' => $settings,
+    'navigation' => $navigation,
+    'title' => $page ? 'Seite bearbeiten' : 'Neue Seite',
+    'subtitle' => 'Strukturiere Inhalte für das Reptilien-Wissensarchiv.',
+    'content' => $content,
+]);

--- a/admin/pages.php
+++ b/admin/pages.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/auth.php';
+
+use App\Core\View;
+use App\Repositories\PageRepository;
+use App\Repositories\SettingRepository;
+
+$pageRepository = PageRepository::make();
+$settings = SettingRepository::make()->all();
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['delete_id'])) {
+    $pageRepository->delete((int) $_POST['delete_id']);
+    header('Location: /admin/pages.php');
+    exit;
+}
+
+$pages = $pageRepository->all();
+
+$navigation = [
+    ['label' => 'Übersicht', 'href' => '/admin/index.php', 'active' => false],
+    ['label' => 'Einstellungen', 'href' => '/admin/settings.php', 'active' => false],
+    ['label' => 'Seiten', 'href' => '/admin/pages.php', 'active' => true],
+    ['label' => 'News', 'href' => '/admin/posts.php', 'active' => false],
+    ['label' => 'User', 'href' => '/admin/users.php', 'active' => false],
+];
+
+ob_start();
+?>
+<div class="flex justify-end mb-4">
+    <a class="rounded-xl bg-gradient-to-r from-cyan-500 to-indigo-500 px-4 py-2 text-sm font-semibold text-slate-950 hover:from-cyan-400 hover:to-indigo-400" href="/admin/page_edit.php">Neue Seite</a>
+</div>
+<div class="overflow-hidden rounded-2xl border border-slate-800">
+    <table class="min-w-full divide-y divide-slate-800 text-sm">
+        <thead class="bg-slate-900/60 text-slate-400 uppercase text-xs tracking-widest">
+            <tr>
+                <th class="px-4 py-3 text-left">Titel</th>
+                <th class="px-4 py-3 text-left">Slug</th>
+                <th class="px-4 py-3 text-left">Aktualisiert</th>
+                <th class="px-4 py-3 text-left">Startseite</th>
+                <th class="px-4 py-3 text-right">Aktionen</th>
+            </tr>
+        </thead>
+        <tbody class="divide-y divide-slate-800">
+            <?php foreach ($pages as $page): ?>
+                <tr class="hover:bg-slate-900/40">
+                    <td class="px-4 py-3 font-medium text-slate-200"><?= htmlspecialchars($page['title']); ?></td>
+                    <td class="px-4 py-3 text-slate-400"><?= htmlspecialchars($page['slug']); ?></td>
+                    <td class="px-4 py-3 text-slate-400"><?= (new DateTimeImmutable($page['updated_at']))->format('d.m.Y H:i'); ?></td>
+                    <td class="px-4 py-3 text-slate-400"><?= (int) $page['is_home'] === 1 ? 'Ja' : 'Nein'; ?></td>
+                    <td class="px-4 py-3">
+                        <div class="flex justify-end gap-2">
+                            <a class="px-3 py-1 rounded-lg border border-slate-700 hover:border-cyan-400" href="/admin/page_edit.php?id=<?= $page['id']; ?>">Bearbeiten</a>
+                            <form method="post" onsubmit="return confirm('Seite wirklich löschen?');">
+                                <input type="hidden" name="delete_id" value="<?= $page['id']; ?>">
+                                <button class="px-3 py-1 rounded-lg border border-rose-600 text-rose-300 hover:bg-rose-600/20" type="submit">Löschen</button>
+                            </form>
+                        </div>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</div>
+<?php
+$content = ob_get_clean();
+
+View::render('admin_layout', [
+    'settings' => $settings,
+    'navigation' => $navigation,
+    'title' => 'Seitenverwaltung',
+    'subtitle' => 'Erstelle und pflege Seiteninhalte.',
+    'content' => $content,
+]);

--- a/admin/post_edit.php
+++ b/admin/post_edit.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/auth.php';
+
+use App\Core\Str;
+use App\Core\View;
+use App\Repositories\PostRepository;
+use App\Repositories\SettingRepository;
+
+$postRepository = PostRepository::make();
+$settings = SettingRepository::make()->all();
+
+$id = isset($_GET['id']) ? (int) $_GET['id'] : null;
+$post = $id ? $postRepository->find($id) : null;
+
+if ($id && !$post) {
+    http_response_code(404);
+    echo 'Beitrag nicht gefunden';
+    exit;
+}
+
+$error = null;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $title = trim($_POST['title'] ?? '');
+    $slug = trim($_POST['slug'] ?? '') ?: Str::slug($title);
+    $excerpt = $_POST['excerpt'] ?? null;
+    $content = $_POST['content'] ?? '';
+    $publishedAt = $_POST['published_at'] ?? null;
+    $publishedAtIso = null;
+
+    if ($title === '' || $content === '') {
+        $error = 'Titel und Inhalt sind erforderlich.';
+    } else {
+        if ($publishedAt) {
+            try {
+                $publishedAtIso = (new \DateTimeImmutable($publishedAt))->format(DATE_ATOM);
+            } catch (\Exception) {
+                $error = 'Ungültiges Veröffentlichungsdatum.';
+            }
+        }
+
+        if ($error === null) {
+        $payload = [
+            'title' => $title,
+            'slug' => Str::slug($slug),
+            'excerpt' => $excerpt,
+            'content' => $content,
+            'published_at' => $publishedAtIso,
+        ];
+
+        if ($post) {
+            $payload['id'] = $post['id'];
+        }
+
+        $postRepository->save($payload);
+        header('Location: /admin/posts.php');
+        exit;
+        }
+    }
+}
+
+$navigation = [
+    ['label' => 'Übersicht', 'href' => '/admin/index.php', 'active' => false],
+    ['label' => 'Einstellungen', 'href' => '/admin/settings.php', 'active' => false],
+    ['label' => 'Seiten', 'href' => '/admin/pages.php', 'active' => false],
+    ['label' => 'News', 'href' => '/admin/posts.php', 'active' => true],
+    ['label' => 'User', 'href' => '/admin/users.php', 'active' => false],
+];
+
+$postData = $post ?? ['title' => '', 'slug' => '', 'excerpt' => '', 'content' => '', 'published_at' => null];
+
+ob_start();
+?>
+<?php if ($error): ?>
+    <div class="rounded-xl border border-rose-500/60 bg-rose-500/10 px-4 py-3 text-sm text-rose-200 mb-4">
+        <?= htmlspecialchars($error); ?>
+    </div>
+<?php endif; ?>
+<form method="post" class="space-y-6">
+    <div class="grid gap-6 md:grid-cols-2">
+        <label class="flex flex-col gap-2 text-sm">
+            <span class="text-slate-300">Titel</span>
+            <input class="rounded-xl border border-slate-700 bg-slate-900/60 px-4 py-3" type="text" name="title" value="<?= htmlspecialchars($postData['title']); ?>" required>
+        </label>
+        <label class="flex flex-col gap-2 text-sm">
+            <span class="text-slate-300">Slug</span>
+            <input class="rounded-xl border border-slate-700 bg-slate-900/60 px-4 py-3" type="text" name="slug" value="<?= htmlspecialchars($postData['slug']); ?>">
+        </label>
+    </div>
+    <label class="flex flex-col gap-2 text-sm">
+        <span class="text-slate-300">Kurzbeschreibung</span>
+        <textarea class="rounded-xl border border-slate-700 bg-slate-900/60 px-4 py-3 h-32" name="excerpt"><?= htmlspecialchars($postData['excerpt']); ?></textarea>
+    </label>
+    <label class="flex flex-col gap-2 text-sm">
+        <span class="text-slate-300">Inhalt (HTML)</span>
+        <textarea class="rounded-xl border border-slate-700 bg-slate-900/60 px-4 py-3 h-80" name="content" required><?= htmlspecialchars($postData['content']); ?></textarea>
+    </label>
+    <label class="flex flex-col gap-2 text-sm">
+        <span class="text-slate-300">Veröffentlichungsdatum</span>
+        <input class="rounded-xl border border-slate-700 bg-slate-900/60 px-4 py-3" type="datetime-local" name="published_at" value="<?= $postData['published_at'] ? (new DateTimeImmutable($postData['published_at']))->format('Y-m-d\TH:i') : ''; ?>">
+        <span class="text-xs text-slate-500">Leer lassen um als Entwurf zu speichern.</span>
+    </label>
+    <div class="flex justify-end gap-3">
+        <a class="px-5 py-3 rounded-xl border border-slate-700 hover:border-slate-500" href="/admin/posts.php">Abbrechen</a>
+        <button class="rounded-xl bg-gradient-to-r from-cyan-500 to-indigo-500 px-6 py-3 text-sm font-semibold text-slate-950 hover:from-cyan-400 hover:to-indigo-400" type="submit">Speichern</button>
+    </div>
+</form>
+<?php
+$content = ob_get_clean();
+
+View::render('admin_layout', [
+    'settings' => $settings,
+    'navigation' => $navigation,
+    'title' => $post ? 'Beitrag bearbeiten' : 'Neuer Beitrag',
+    'subtitle' => 'Teile Wissen und Neuigkeiten mit der Community.',
+    'content' => $content,
+]);

--- a/admin/posts.php
+++ b/admin/posts.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/auth.php';
+
+use App\Core\View;
+use App\Repositories\PostRepository;
+use App\Repositories\SettingRepository;
+
+$postRepository = PostRepository::make();
+$settings = SettingRepository::make()->all();
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['delete_id'])) {
+    $postRepository->delete((int) $_POST['delete_id']);
+    header('Location: /admin/posts.php');
+    exit;
+}
+
+$posts = $postRepository->all();
+
+$navigation = [
+    ['label' => 'Übersicht', 'href' => '/admin/index.php', 'active' => false],
+    ['label' => 'Einstellungen', 'href' => '/admin/settings.php', 'active' => false],
+    ['label' => 'Seiten', 'href' => '/admin/pages.php', 'active' => false],
+    ['label' => 'News', 'href' => '/admin/posts.php', 'active' => true],
+    ['label' => 'User', 'href' => '/admin/users.php', 'active' => false],
+];
+
+ob_start();
+?>
+<div class="flex justify-end mb-4">
+    <a class="rounded-xl bg-gradient-to-r from-cyan-500 to-indigo-500 px-4 py-2 text-sm font-semibold text-slate-950 hover:from-cyan-400 hover:to-indigo-400" href="/admin/post_edit.php">Neuer Beitrag</a>
+</div>
+<div class="overflow-hidden rounded-2xl border border-slate-800">
+    <table class="min-w-full divide-y divide-slate-800 text-sm">
+        <thead class="bg-slate-900/60 text-slate-400 uppercase text-xs tracking-widest">
+            <tr>
+                <th class="px-4 py-3 text-left">Titel</th>
+                <th class="px-4 py-3 text-left">Slug</th>
+                <th class="px-4 py-3 text-left">Veröffentlicht</th>
+                <th class="px-4 py-3 text-left">Aktualisiert</th>
+                <th class="px-4 py-3 text-right">Aktionen</th>
+            </tr>
+        </thead>
+        <tbody class="divide-y divide-slate-800">
+            <?php foreach ($posts as $post): ?>
+                <tr class="hover:bg-slate-900/40">
+                    <td class="px-4 py-3 font-medium text-slate-200"><?= htmlspecialchars($post['title']); ?></td>
+                    <td class="px-4 py-3 text-slate-400"><?= htmlspecialchars($post['slug']); ?></td>
+                    <td class="px-4 py-3 text-slate-400"><?= $post['published_at'] ? (new DateTimeImmutable($post['published_at']))->format('d.m.Y H:i') : 'Entwurf'; ?></td>
+                    <td class="px-4 py-3 text-slate-400"><?= (new DateTimeImmutable($post['updated_at']))->format('d.m.Y H:i'); ?></td>
+                    <td class="px-4 py-3">
+                        <div class="flex justify-end gap-2">
+                            <a class="px-3 py-1 rounded-lg border border-slate-700 hover:border-cyan-400" href="/admin/post_edit.php?id=<?= $post['id']; ?>">Bearbeiten</a>
+                            <form method="post" onsubmit="return confirm('Beitrag wirklich löschen?');">
+                                <input type="hidden" name="delete_id" value="<?= $post['id']; ?>">
+                                <button class="px-3 py-1 rounded-lg border border-rose-600 text-rose-300 hover:bg-rose-600/20" type="submit">Löschen</button>
+                            </form>
+                        </div>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</div>
+<?php
+$content = ob_get_clean();
+
+View::render('admin_layout', [
+    'settings' => $settings,
+    'navigation' => $navigation,
+    'title' => 'News Verwaltung',
+    'subtitle' => 'Publiziere Neuigkeiten und Forschungsergebnisse.',
+    'content' => $content,
+]);

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/auth.php';
+
+use App\Core\View;
+use App\Repositories\SettingRepository;
+
+$settingsRepo = SettingRepository::make();
+$settings = $settingsRepo->all();
+$message = null;
+$error = null;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $updated = [
+        'site_title' => trim($_POST['site_title'] ?? ''),
+        'logo_text' => trim($_POST['logo_text'] ?? ''),
+        'menu_structure' => $_POST['menu_structure'] ?? '[]',
+        'sidebar_content' => $_POST['sidebar_content'] ?? '',
+        'header_content' => $_POST['header_content'] ?? '',
+        'footer_content' => $_POST['footer_content'] ?? '',
+        'homepage_intro' => $_POST['homepage_intro'] ?? '',
+    ];
+
+    try {
+        json_decode($updated['menu_structure'], true, 512, JSON_THROW_ON_ERROR);
+        $settingsRepo->updateMany($updated);
+        $settings = $settingsRepo->all();
+        $message = 'Einstellungen wurden gespeichert.';
+    } catch (\JsonException $exception) {
+        $error = 'Menüstruktur ist kein gültiges JSON: ' . $exception->getMessage();
+    }
+}
+
+$navigation = [
+    ['label' => 'Übersicht', 'href' => '/admin/index.php', 'active' => false],
+    ['label' => 'Einstellungen', 'href' => '/admin/settings.php', 'active' => true],
+    ['label' => 'Seiten', 'href' => '/admin/pages.php', 'active' => false],
+    ['label' => 'News', 'href' => '/admin/posts.php', 'active' => false],
+    ['label' => 'User', 'href' => '/admin/users.php', 'active' => false],
+];
+
+ob_start();
+?>
+<?php if ($message): ?>
+    <div class="rounded-xl border border-emerald-500/60 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-200">
+        <?= htmlspecialchars($message); ?>
+    </div>
+<?php endif; ?>
+<?php if ($error): ?>
+    <div class="rounded-xl border border-rose-500/60 bg-rose-500/10 px-4 py-3 text-sm text-rose-200">
+        <?= htmlspecialchars($error); ?>
+    </div>
+<?php endif; ?>
+<form method="post" class="space-y-6">
+    <div class="grid gap-6 md:grid-cols-2">
+        <label class="flex flex-col gap-2 text-sm">
+            <span class="text-slate-300">Seitentitel</span>
+            <input class="rounded-xl border border-slate-700 bg-slate-900/60 px-4 py-3" type="text" name="site_title" value="<?= htmlspecialchars($settings['site_title'] ?? ''); ?>" required>
+        </label>
+        <label class="flex flex-col gap-2 text-sm">
+            <span class="text-slate-300">Logo Text</span>
+            <input class="rounded-xl border border-slate-700 bg-slate-900/60 px-4 py-3" type="text" name="logo_text" value="<?= htmlspecialchars($settings['logo_text'] ?? ''); ?>">
+        </label>
+    </div>
+    <label class="flex flex-col gap-2 text-sm">
+        <span class="text-slate-300">Menüstruktur (JSON)</span>
+        <textarea class="rounded-xl border border-slate-700 bg-slate-900/60 px-4 py-3 h-48" name="menu_structure" required><?= htmlspecialchars($settings['menu_structure'] ?? '[]'); ?></textarea>
+        <span class="text-xs text-slate-500">Beispiel: [{"label":"Startseite","url":"/"}]</span>
+    </label>
+    <div class="grid gap-6 md:grid-cols-2">
+        <label class="flex flex-col gap-2 text-sm">
+            <span class="text-slate-300">Sidebar Inhalt (HTML)</span>
+            <textarea class="rounded-xl border border-slate-700 bg-slate-900/60 px-4 py-3 h-48" name="sidebar_content"><?= htmlspecialchars($settings['sidebar_content'] ?? ''); ?></textarea>
+        </label>
+        <label class="flex flex-col gap-2 text-sm">
+            <span class="text-slate-300">Startseiten Intro (HTML)</span>
+            <textarea class="rounded-xl border border-slate-700 bg-slate-900/60 px-4 py-3 h-48" name="homepage_intro"><?= htmlspecialchars($settings['homepage_intro'] ?? ''); ?></textarea>
+        </label>
+    </div>
+    <div class="grid gap-6 md:grid-cols-2">
+        <label class="flex flex-col gap-2 text-sm">
+            <span class="text-slate-300">Header Inhalt (HTML)</span>
+            <textarea class="rounded-xl border border-slate-700 bg-slate-900/60 px-4 py-3 h-36" name="header_content"><?= htmlspecialchars($settings['header_content'] ?? ''); ?></textarea>
+        </label>
+        <label class="flex flex-col gap-2 text-sm">
+            <span class="text-slate-300">Footer Inhalt (HTML)</span>
+            <textarea class="rounded-xl border border-slate-700 bg-slate-900/60 px-4 py-3 h-36" name="footer_content"><?= htmlspecialchars($settings['footer_content'] ?? ''); ?></textarea>
+        </label>
+    </div>
+    <div class="flex justify-end">
+        <button class="rounded-xl bg-gradient-to-r from-cyan-500 to-indigo-500 px-6 py-3 text-sm font-semibold text-slate-950 hover:from-cyan-400 hover:to-indigo-400" type="submit">Speichern</button>
+    </div>
+</form>
+<?php
+$content = ob_get_clean();
+
+View::render('admin_layout', [
+    'settings' => $settings,
+    'navigation' => $navigation,
+    'title' => 'Einstellungen',
+    'subtitle' => 'Passe Branding und Layout an.',
+    'content' => $content,
+]);

--- a/admin/user_edit.php
+++ b/admin/user_edit.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/auth.php';
+
+use App\Core\View;
+use App\Repositories\SettingRepository;
+use App\Repositories\UserRepository;
+
+if (!$auth->checkRole('admin')) {
+    http_response_code(403);
+    echo 'Nur Administratoren dürfen Benutzer verwalten.';
+    exit;
+}
+
+$userRepository = UserRepository::make();
+$settings = SettingRepository::make()->all();
+
+$id = isset($_GET['id']) ? (int) $_GET['id'] : null;
+$user = $id ? $userRepository->find($id) : null;
+
+if ($id && !$user) {
+    http_response_code(404);
+    echo 'Benutzer nicht gefunden';
+    exit;
+}
+
+$error = null;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $name = trim($_POST['name'] ?? '');
+    $email = trim($_POST['email'] ?? '');
+    $role = $_POST['role'] ?? 'editor';
+    $password = $_POST['password'] ?? '';
+
+    if ($name === '' || $email === '') {
+        $error = 'Name und E-Mail sind erforderlich.';
+    } elseif (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+        $error = 'Bitte eine gültige E-Mail-Adresse eingeben.';
+    } else {
+        $payload = [
+            'name' => $name,
+            'email' => $email,
+            'role' => $role,
+        ];
+
+        if ($password !== '') {
+            $payload['password'] = $password;
+        }
+
+        if ($user) {
+            $payload['id'] = $user['id'];
+        }
+
+        $userRepository->save($payload);
+        header('Location: /admin/users.php');
+        exit;
+    }
+}
+
+$navigation = [
+    ['label' => 'Übersicht', 'href' => '/admin/index.php', 'active' => false],
+    ['label' => 'Einstellungen', 'href' => '/admin/settings.php', 'active' => false],
+    ['label' => 'Seiten', 'href' => '/admin/pages.php', 'active' => false],
+    ['label' => 'News', 'href' => '/admin/posts.php', 'active' => false],
+    ['label' => 'User', 'href' => '/admin/users.php', 'active' => true],
+];
+
+$userData = $user ?? ['name' => '', 'email' => '', 'role' => 'editor'];
+
+ob_start();
+?>
+<?php if ($error): ?>
+    <div class="rounded-xl border border-rose-500/60 bg-rose-500/10 px-4 py-3 text-sm text-rose-200 mb-4">
+        <?= htmlspecialchars($error); ?>
+    </div>
+<?php endif; ?>
+<form method="post" class="space-y-6">
+    <div class="grid gap-6 md:grid-cols-2">
+        <label class="flex flex-col gap-2 text-sm">
+            <span class="text-slate-300">Name</span>
+            <input class="rounded-xl border border-slate-700 bg-slate-900/60 px-4 py-3" type="text" name="name" value="<?= htmlspecialchars($userData['name']); ?>" required>
+        </label>
+        <label class="flex flex-col gap-2 text-sm">
+            <span class="text-slate-300">E-Mail</span>
+            <input class="rounded-xl border border-slate-700 bg-slate-900/60 px-4 py-3" type="email" name="email" value="<?= htmlspecialchars($userData['email']); ?>" required>
+        </label>
+    </div>
+    <label class="flex flex-col gap-2 text-sm">
+        <span class="text-slate-300">Rolle</span>
+        <select class="rounded-xl border border-slate-700 bg-slate-900/60 px-4 py-3" name="role">
+            <option value="admin" <?= $userData['role'] === 'admin' ? 'selected' : ''; ?>>Administrator</option>
+            <option value="editor" <?= $userData['role'] === 'editor' ? 'selected' : ''; ?>>Editor</option>
+        </select>
+    </label>
+    <label class="flex flex-col gap-2 text-sm">
+        <span class="text-slate-300">Passwort <?= $user ? '(leer lassen für keine Änderung)' : ''; ?></span>
+        <input class="rounded-xl border border-slate-700 bg-slate-900/60 px-4 py-3" type="password" name="password" <?= $user ? '' : 'required'; ?>>
+    </label>
+    <div class="flex justify-end gap-3">
+        <a class="px-5 py-3 rounded-xl border border-slate-700 hover:border-slate-500" href="/admin/users.php">Abbrechen</a>
+        <button class="rounded-xl bg-gradient-to-r from-cyan-500 to-indigo-500 px-6 py-3 text-sm font-semibold text-slate-950 hover:from-cyan-400 hover:to-indigo-400" type="submit">Speichern</button>
+    </div>
+</form>
+<?php
+$content = ob_get_clean();
+
+View::render('admin_layout', [
+    'settings' => $settings,
+    'navigation' => $navigation,
+    'title' => $user ? 'Benutzer bearbeiten' : 'Neuer Benutzer',
+    'subtitle' => 'Lege Rollen und Berechtigungen fest.',
+    'content' => $content,
+]);

--- a/admin/users.php
+++ b/admin/users.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/auth.php';
+
+use App\Core\View;
+use App\Repositories\SettingRepository;
+use App\Repositories\UserRepository;
+
+$userRepository = UserRepository::make();
+$settings = SettingRepository::make()->all();
+
+if (!$auth->checkRole('admin')) {
+    http_response_code(403);
+    echo 'Nur Administratoren dürfen Benutzer verwalten.';
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['delete_id'])) {
+    if ((int) $_POST['delete_id'] === (int) ($currentUser['id'] ?? 0)) {
+        $error = 'Du kannst dich nicht selbst löschen.';
+    } else {
+        $userRepository->delete((int) $_POST['delete_id']);
+        header('Location: /admin/users.php');
+        exit;
+    }
+}
+
+$users = $userRepository->all();
+$error = $error ?? null;
+
+$navigation = [
+    ['label' => 'Übersicht', 'href' => '/admin/index.php', 'active' => false],
+    ['label' => 'Einstellungen', 'href' => '/admin/settings.php', 'active' => false],
+    ['label' => 'Seiten', 'href' => '/admin/pages.php', 'active' => false],
+    ['label' => 'News', 'href' => '/admin/posts.php', 'active' => false],
+    ['label' => 'User', 'href' => '/admin/users.php', 'active' => true],
+];
+
+ob_start();
+?>
+<?php if ($error): ?>
+    <div class="rounded-xl border border-rose-500/60 bg-rose-500/10 px-4 py-3 text-sm text-rose-200 mb-4">
+        <?= htmlspecialchars($error); ?>
+    </div>
+<?php endif; ?>
+<div class="flex justify-end mb-4">
+    <a class="rounded-xl bg-gradient-to-r from-cyan-500 to-indigo-500 px-4 py-2 text-sm font-semibold text-slate-950 hover:from-cyan-400 hover:to-indigo-400" href="/admin/user_edit.php">Neuer Benutzer</a>
+</div>
+<div class="overflow-hidden rounded-2xl border border-slate-800">
+    <table class="min-w-full divide-y divide-slate-800 text-sm">
+        <thead class="bg-slate-900/60 text-slate-400 uppercase text-xs tracking-widest">
+            <tr>
+                <th class="px-4 py-3 text-left">Name</th>
+                <th class="px-4 py-3 text-left">E-Mail</th>
+                <th class="px-4 py-3 text-left">Rolle</th>
+                <th class="px-4 py-3 text-left">Aktualisiert</th>
+                <th class="px-4 py-3 text-right">Aktionen</th>
+            </tr>
+        </thead>
+        <tbody class="divide-y divide-slate-800">
+            <?php foreach ($users as $user): ?>
+                <tr class="hover:bg-slate-900/40">
+                    <td class="px-4 py-3 font-medium text-slate-200"><?= htmlspecialchars($user['name']); ?></td>
+                    <td class="px-4 py-3 text-slate-400"><?= htmlspecialchars($user['email']); ?></td>
+                    <td class="px-4 py-3 text-slate-400"><?= htmlspecialchars($user['role']); ?></td>
+                    <td class="px-4 py-3 text-slate-400"><?= (new DateTimeImmutable($user['updated_at']))->format('d.m.Y H:i'); ?></td>
+                    <td class="px-4 py-3">
+                        <div class="flex justify-end gap-2">
+                            <a class="px-3 py-1 rounded-lg border border-slate-700 hover:border-cyan-400" href="/admin/user_edit.php?id=<?= $user['id']; ?>">Bearbeiten</a>
+                            <?php if ((int) $user['id'] !== (int) ($currentUser['id'] ?? 0)): ?>
+                                <form method="post" onsubmit="return confirm('Benutzer wirklich löschen?');">
+                                    <input type="hidden" name="delete_id" value="<?= $user['id']; ?>">
+                                    <button class="px-3 py-1 rounded-lg border border-rose-600 text-rose-300 hover:bg-rose-600/20" type="submit">Löschen</button>
+                                </form>
+                            <?php endif; ?>
+                        </div>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</div>
+<?php
+$content = ob_get_clean();
+
+View::render('admin_layout', [
+    'settings' => $settings,
+    'navigation' => $navigation,
+    'title' => 'Benutzerverwaltung',
+    'subtitle' => 'Steuere den Zugriff auf dein Reptilien-Wissensarchiv.',
+    'content' => $content,
+]);

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+session_start();
+
+const BASE_PATH = __DIR__;
+
+spl_autoload_register(static function (string $class): void {
+    $prefix = 'App\\';
+    $baseDir = __DIR__ . '/src/';
+
+    $len = strlen($prefix);
+    if (strncmp($prefix, $class, $len) !== 0) {
+        return;
+    }
+
+    $relativeClass = substr($class, $len);
+    $file = $baseDir . str_replace('\\', '/', $relativeClass) . '.php';
+
+    if (file_exists($file)) {
+        require $file;
+    }
+});
+
+require_once __DIR__ . '/config/app.php';
+
+use App\Core\Database;
+use App\Services\VersionManager;
+
+$database = Database::getInstance();
+$database->initialize();
+
+VersionManager::initialize($database);

--- a/config/app.php
+++ b/config/app.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Core\Config;
+
+Config::set([
+    'app_name' => 'Dragon Reptiles CMS',
+    'environment' => 'development',
+    'database' => [
+        'driver' => 'sqlite',
+        'path' => BASE_PATH . '/storage/database.sqlite',
+    ],
+    'security' => [
+        'password_algo' => PASSWORD_ARGON2ID,
+    ],
+]);

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../bootstrap.php';
+
+use App\Core\View;
+use App\Repositories\PageRepository;
+use App\Repositories\PostRepository;
+use App\Repositories\SettingRepository;
+
+$settingsRepo = SettingRepository::make();
+$pageRepo = PageRepository::make();
+$postRepo = PostRepository::make();
+
+$settings = $settingsRepo->all();
+$home = $pageRepo->findHomePage();
+$posts = array_slice($postRepo->published(), 0, 3);
+
+ob_start();
+?>
+<div class="space-y-8">
+    <section class="p-8 rounded-3xl bg-gradient-to-r from-cyan-500/20 via-indigo-500/20 to-purple-500/20 border border-slate-800">
+        <?= $settings['homepage_intro'] ?? '<p>Erkunde die faszinierende Vielfalt der Reptilienwelt mit datengestützten Einblicken.</p>'; ?>
+    </section>
+    <?php if ($home): ?>
+        <section class="space-y-4 leading-relaxed text-slate-200">
+            <?= $home['content']; ?>
+        </section>
+    <?php endif; ?>
+    <?php if ($posts): ?>
+        <section>
+            <h2 class="text-xl font-semibold mb-4">Aktuelle News</h2>
+            <div class="grid gap-4 md:grid-cols-3">
+                <?php foreach ($posts as $post): ?>
+                    <article class="rounded-2xl border border-slate-800 p-5 bg-slate-900/40 backdrop-blur">
+                        <h3 class="text-lg font-semibold text-cyan-200"><a href="/news.php?slug=<?= urlencode($post['slug']); ?>" class="hover:underline"><?= htmlspecialchars($post['title']); ?></a></h3>
+                        <p class="text-sm text-slate-400 mt-2"><?= htmlspecialchars($post['excerpt'] ?? mb_substr(strip_tags($post['content']), 0, 160) . '…'); ?></p>
+                        <?php if ($post['published_at']): ?>
+                            <p class="text-xs text-slate-500 mt-4">Veröffentlicht am <?= (new DateTimeImmutable($post['published_at']))->format('d.m.Y'); ?></p>
+                        <?php endif; ?>
+                    </article>
+                <?php endforeach; ?>
+            </div>
+        </section>
+    <?php endif; ?>
+</div>
+<?php
+$content = ob_get_clean();
+
+View::render('public_layout', compact('settings', 'content'));

--- a/public/news.php
+++ b/public/news.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../bootstrap.php';
+
+use App\Core\View;
+use App\Repositories\PostRepository;
+use App\Repositories\SettingRepository;
+
+$settings = SettingRepository::make()->all();
+$postRepository = PostRepository::make();
+
+$slug = $_GET['slug'] ?? null;
+
+if ($slug) {
+    $post = $postRepository->findBySlug($slug);
+    if (!$post) {
+        http_response_code(404);
+        echo 'Beitrag nicht gefunden';
+        exit;
+    }
+
+    ob_start();
+    ?>
+    <article class="space-y-6">
+        <header>
+            <h1 class="text-3xl font-bold text-cyan-200"><?= htmlspecialchars($post['title']); ?></h1>
+            <?php if ($post['published_at']): ?>
+                <p class="text-sm text-slate-400 mt-2">Veröffentlicht am <?= (new DateTimeImmutable($post['published_at']))->format('d.m.Y H:i'); ?></p>
+            <?php endif; ?>
+        </header>
+        <section class="space-y-4 leading-relaxed text-slate-200">
+            <?= $post['content']; ?>
+        </section>
+    </article>
+    <?php
+    $content = ob_get_clean();
+} else {
+    $posts = $postRepository->published();
+
+    ob_start();
+    ?>
+    <section class="space-y-6">
+        <header>
+            <h1 class="text-3xl font-bold text-cyan-200">News</h1>
+            <p class="text-sm text-slate-400">Aktuelle Entwicklungen aus Haltung, Zucht und Forschung.</p>
+        </header>
+        <div class="grid gap-4">
+            <?php foreach ($posts as $post): ?>
+                <article class="rounded-2xl border border-slate-800 p-6 bg-slate-900/50">
+                    <h2 class="text-xl font-semibold text-cyan-200"><a href="?slug=<?= urlencode($post['slug']); ?>" class="hover:underline"><?= htmlspecialchars($post['title']); ?></a></h2>
+                    <p class="text-sm text-slate-400 mt-2"><?= htmlspecialchars($post['excerpt'] ?? mb_substr(strip_tags($post['content']), 0, 200) . '…'); ?></p>
+                    <?php if ($post['published_at']): ?>
+                        <p class="text-xs text-slate-500 mt-4">Veröffentlicht am <?= (new DateTimeImmutable($post['published_at']))->format('d.m.Y'); ?></p>
+                    <?php endif; ?>
+                </article>
+            <?php endforeach; ?>
+        </div>
+    </section>
+    <?php
+    $content = ob_get_clean();
+}
+
+View::render('public_layout', compact('settings', 'content'));

--- a/public/page.php
+++ b/public/page.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../bootstrap.php';
+
+use App\Core\View;
+use App\Repositories\PageRepository;
+use App\Repositories\SettingRepository;
+
+$slug = $_GET['slug'] ?? null;
+
+if (!$slug) {
+    header('Location: /');
+    exit;
+}
+
+$page = PageRepository::make()->findBySlug($slug);
+
+if (!$page) {
+    http_response_code(404);
+    echo 'Seite nicht gefunden';
+    exit;
+}
+
+$settings = SettingRepository::make()->all();
+
+ob_start();
+?>
+<article class="space-y-6">
+    <header>
+        <h1 class="text-3xl font-bold text-cyan-200"><?= htmlspecialchars($page['title']); ?></h1>
+    </header>
+    <section class="space-y-4 leading-relaxed text-slate-200">
+        <?= $page['content']; ?>
+    </section>
+</article>
+<?php
+$content = ob_get_clean();
+
+View::render('public_layout', compact('settings', 'content'));

--- a/src/Core/Config.php
+++ b/src/Core/Config.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Core;
+
+final class Config
+{
+    private static array $config = [];
+
+    public static function set(array $config): void
+    {
+        self::$config = $config;
+    }
+
+    public static function get(string $key, mixed $default = null): mixed
+    {
+        $segments = explode('.', $key);
+        $value = self::$config;
+
+        foreach ($segments as $segment) {
+            if (!is_array($value) || !array_key_exists($segment, $value)) {
+                return $default;
+            }
+            $value = $value[$segment];
+        }
+
+        return $value;
+    }
+}

--- a/src/Core/Database.php
+++ b/src/Core/Database.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Core;
+
+use PDO;
+use PDOException;
+
+final class Database
+{
+    private static ?self $instance = null;
+    private ?PDO $connection = null;
+
+    private function __construct()
+    {
+    }
+
+    public static function getInstance(): self
+    {
+        if (self::$instance === null) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    public function initialize(): void
+    {
+        if ($this->connection !== null) {
+            return;
+        }
+
+        $databaseConfig = Config::get('database');
+
+        if (!$databaseConfig) {
+            throw new \RuntimeException('Database configuration missing.');
+        }
+
+        if ($databaseConfig['driver'] === 'sqlite') {
+            $path = $databaseConfig['path'];
+            $directory = dirname($path);
+
+            if (!is_dir($directory)) {
+                mkdir($directory, 0o755, true);
+            }
+
+            $this->connection = new PDO('sqlite:' . $path, options: [
+                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+            ]);
+        } else {
+            throw new \RuntimeException('Unsupported database driver: ' . $databaseConfig['driver']);
+        }
+
+        $this->runMigrations();
+    }
+
+    public function getConnection(): PDO
+    {
+        if ($this->connection === null) {
+            throw new \RuntimeException('Database has not been initialized.');
+        }
+
+        return $this->connection;
+    }
+
+    private function runMigrations(): void
+    {
+        $pdo = $this->getConnection();
+
+        $pdo->exec('CREATE TABLE IF NOT EXISTS migrations (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL UNIQUE,
+            executed_at TEXT NOT NULL
+        )');
+
+        $migrations = [
+            '20240101_000000_initial_schema' => function (PDO $connection): void {
+                $connection->exec('CREATE TABLE settings (
+                    key TEXT PRIMARY KEY,
+                    value TEXT NOT NULL
+                )');
+
+                $connection->exec('CREATE TABLE users (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT NOT NULL,
+                    email TEXT NOT NULL UNIQUE,
+                    password TEXT NOT NULL,
+                    role TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                )');
+
+                $connection->exec('CREATE TABLE pages (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    title TEXT NOT NULL,
+                    slug TEXT NOT NULL UNIQUE,
+                    content TEXT NOT NULL,
+                    is_home INTEGER NOT NULL DEFAULT 0,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                )');
+
+                $connection->exec('CREATE TABLE posts (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    title TEXT NOT NULL,
+                    slug TEXT NOT NULL UNIQUE,
+                    excerpt TEXT,
+                    content TEXT NOT NULL,
+                    published_at TEXT,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                )');
+
+                $connection->exec('CREATE TABLE version_history (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    major INTEGER NOT NULL,
+                    minor INTEGER NOT NULL,
+                    patch INTEGER NOT NULL,
+                    note TEXT,
+                    created_at TEXT NOT NULL
+                )');
+
+                $now = (new \DateTimeImmutable())->format(DATE_ATOM);
+
+                $connection->prepare('INSERT INTO users (name, email, password, role, created_at, updated_at) VALUES (:name, :email, :password, :role, :created_at, :updated_at)')
+                    ->execute([
+                        'name' => 'Administrator',
+                        'email' => 'admin@example.com',
+                        'password' => password_hash('ChangeMe123!', Config::get('security.password_algo')),
+                        'role' => 'admin',
+                        'created_at' => $now,
+                        'updated_at' => $now,
+                    ]);
+
+                $settings = [
+                    ['site_title', 'Dragon Reptiles CMS'],
+                    ['logo_text', 'Dragon Reptiles Knowledge Hub'],
+                    ['menu_structure', json_encode([
+                        ['label' => 'Startseite', 'url' => '/'],
+                        ['label' => 'News', 'url' => '/news.php'],
+                    ], JSON_THROW_ON_ERROR)],
+                    ['sidebar_content', '<p>Willkommen im Reptilien Wissenszentrum.</p>'],
+                    ['header_content', '<h1>Dragon Reptiles</h1>'],
+                    ['footer_content', '<p>&copy; ' . date('Y') . ' Dragon Reptiles</p>'],
+                    ['homepage_intro', '<p>Erkunde moderne Einblicke in die Welt der Reptilien.</p>'],
+                ];
+
+                $insertSetting = $connection->prepare('INSERT INTO settings (key, value) VALUES (:key, :value)');
+                foreach ($settings as [$key, $value]) {
+                    $insertSetting->execute(['key' => $key, 'value' => $value]);
+                }
+
+                $pageStmt = $connection->prepare('INSERT INTO pages (title, slug, content, is_home, created_at, updated_at) VALUES (:title, :slug, :content, :is_home, :created_at, :updated_at)');
+                $pageStmt->execute([
+                    'title' => 'Startseite',
+                    'slug' => 'startseite',
+                    'content' => '<h2>Willkommen</h2><p>Dieses CMS unterstützt moderne Reptilienforschung und -verwaltung.</p>',
+                    'is_home' => 1,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ]);
+
+                $versionStmt = $connection->prepare('INSERT INTO version_history (major, minor, patch, note, created_at) VALUES (:major, :minor, :patch, :note, :created_at)');
+                $versionStmt->execute([
+                    'major' => 0,
+                    'minor' => 1,
+                    'patch' => 0,
+                    'note' => 'Initiale CMS Bereitstellung',
+                    'created_at' => $now,
+                ]);
+            },
+        ];
+
+        foreach ($migrations as $name => $migration) {
+            $stmt = $pdo->prepare('SELECT COUNT(*) FROM migrations WHERE name = :name');
+            $stmt->execute(['name' => $name]);
+            $hasRun = (int) $stmt->fetchColumn() === 1;
+
+            if (!$hasRun) {
+                $pdo->beginTransaction();
+                try {
+                    $migration($pdo);
+                    $insert = $pdo->prepare('INSERT INTO migrations (name, executed_at) VALUES (:name, :executed_at)');
+                    $insert->execute([
+                        'name' => $name,
+                        'executed_at' => (new \DateTimeImmutable())->format(DATE_ATOM),
+                    ]);
+                    $pdo->commit();
+                } catch (PDOException $exception) {
+                    $pdo->rollBack();
+                    throw new \RuntimeException('Migration failed: ' . $exception->getMessage(), 0, $exception);
+                }
+            }
+        }
+    }
+}

--- a/src/Core/Str.php
+++ b/src/Core/Str.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Core;
+
+final class Str
+{
+    private function __construct()
+    {
+    }
+
+    public static function slug(string $value): string
+    {
+        $transliterated = iconv('UTF-8', 'ASCII//TRANSLIT', $value);
+        if ($transliterated === false) {
+            $transliterated = $value;
+        }
+
+        $normalized = strtolower($transliterated);
+        $normalized = preg_replace('/[^a-z0-9]+/i', '-', $normalized) ?? '';
+
+        return trim($normalized, '-') ?: 'inhalt';
+    }
+}

--- a/src/Core/View.php
+++ b/src/Core/View.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Core;
+
+final class View
+{
+    private function __construct()
+    {
+    }
+
+    public static function render(string $template, array $data = []): void
+    {
+        extract($data, EXTR_OVERWRITE);
+        require BASE_PATH . '/storage/templates/' . $template . '.php';
+    }
+}

--- a/src/Repositories/PageRepository.php
+++ b/src/Repositories/PageRepository.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repositories;
+
+use App\Core\Database;
+use PDO;
+
+final class PageRepository
+{
+    public function __construct(private readonly PDO $connection)
+    {
+    }
+
+    public static function make(): self
+    {
+        return new self(Database::getInstance()->getConnection());
+    }
+
+    public function all(): array
+    {
+        $stmt = $this->connection->query('SELECT * FROM pages ORDER BY title');
+        return $stmt->fetchAll();
+    }
+
+    public function findBySlug(string $slug): ?array
+    {
+        $stmt = $this->connection->prepare('SELECT * FROM pages WHERE slug = :slug');
+        $stmt->execute(['slug' => $slug]);
+        $result = $stmt->fetch();
+
+        return $result ?: null;
+    }
+
+    public function findHomePage(): ?array
+    {
+        $stmt = $this->connection->query('SELECT * FROM pages WHERE is_home = 1 LIMIT 1');
+        $result = $stmt->fetch();
+
+        return $result ?: null;
+    }
+
+    public function find(int $id): ?array
+    {
+        $stmt = $this->connection->prepare('SELECT * FROM pages WHERE id = :id');
+        $stmt->execute(['id' => $id]);
+        $result = $stmt->fetch();
+
+        return $result ?: null;
+    }
+
+    public function save(array $data): void
+    {
+        $now = (new \DateTimeImmutable())->format(DATE_ATOM);
+        if (isset($data['id'])) {
+            $this->connection->prepare('UPDATE pages SET title = :title, slug = :slug, content = :content, is_home = :is_home, updated_at = :updated_at WHERE id = :id')
+                ->execute([
+                    'id' => $data['id'],
+                    'title' => $data['title'],
+                    'slug' => $data['slug'],
+                    'content' => $data['content'],
+                    'is_home' => $data['is_home'] ?? 0,
+                    'updated_at' => $now,
+                ]);
+        } else {
+            $this->connection->prepare('INSERT INTO pages (title, slug, content, is_home, created_at, updated_at) VALUES (:title, :slug, :content, :is_home, :created_at, :updated_at)')
+                ->execute([
+                    'title' => $data['title'],
+                    'slug' => $data['slug'],
+                    'content' => $data['content'],
+                    'is_home' => $data['is_home'] ?? 0,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ]);
+        }
+
+        if (!empty($data['is_home'])) {
+            $this->connection->prepare('UPDATE pages SET is_home = CASE WHEN id = :id THEN 1 ELSE 0 END')->execute(['id' => $data['id'] ?? $this->connection->lastInsertId()]);
+        }
+    }
+
+    public function delete(int $id): void
+    {
+        $this->connection->prepare('DELETE FROM pages WHERE id = :id')->execute(['id' => $id]);
+    }
+}

--- a/src/Repositories/PostRepository.php
+++ b/src/Repositories/PostRepository.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repositories;
+
+use App\Core\Database;
+use PDO;
+
+final class PostRepository
+{
+    public function __construct(private readonly PDO $connection)
+    {
+    }
+
+    public static function make(): self
+    {
+        return new self(Database::getInstance()->getConnection());
+    }
+
+    public function all(): array
+    {
+        $stmt = $this->connection->query('SELECT * FROM posts ORDER BY COALESCE(published_at, created_at) DESC');
+        return $stmt->fetchAll();
+    }
+
+    public function published(): array
+    {
+        $stmt = $this->connection->query('SELECT * FROM posts WHERE published_at IS NOT NULL ORDER BY published_at DESC');
+        return $stmt->fetchAll();
+    }
+
+    public function findBySlug(string $slug): ?array
+    {
+        $stmt = $this->connection->prepare('SELECT * FROM posts WHERE slug = :slug');
+        $stmt->execute(['slug' => $slug]);
+        $result = $stmt->fetch();
+
+        return $result ?: null;
+    }
+
+    public function find(int $id): ?array
+    {
+        $stmt = $this->connection->prepare('SELECT * FROM posts WHERE id = :id');
+        $stmt->execute(['id' => $id]);
+        $result = $stmt->fetch();
+
+        return $result ?: null;
+    }
+
+    public function save(array $data): void
+    {
+        $now = (new \DateTimeImmutable())->format(DATE_ATOM);
+        $payload = [
+            'title' => $data['title'],
+            'slug' => $data['slug'],
+            'excerpt' => $data['excerpt'] ?? null,
+            'content' => $data['content'],
+            'published_at' => $data['published_at'] ?? null,
+        ];
+
+        if (isset($data['id'])) {
+            $payload['id'] = $data['id'];
+            $payload['updated_at'] = $now;
+            $this->connection->prepare('UPDATE posts SET title = :title, slug = :slug, excerpt = :excerpt, content = :content, published_at = :published_at, updated_at = :updated_at WHERE id = :id')
+                ->execute($payload);
+        } else {
+            $payload['created_at'] = $now;
+            $payload['updated_at'] = $now;
+            $this->connection->prepare('INSERT INTO posts (title, slug, excerpt, content, published_at, created_at, updated_at) VALUES (:title, :slug, :excerpt, :content, :published_at, :created_at, :updated_at)')
+                ->execute($payload);
+        }
+    }
+
+    public function delete(int $id): void
+    {
+        $this->connection->prepare('DELETE FROM posts WHERE id = :id')->execute(['id' => $id]);
+    }
+}

--- a/src/Repositories/SettingRepository.php
+++ b/src/Repositories/SettingRepository.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repositories;
+
+use App\Core\Database;
+use PDO;
+
+final class SettingRepository
+{
+    public function __construct(private readonly PDO $connection)
+    {
+    }
+
+    public static function make(): self
+    {
+        return new self(Database::getInstance()->getConnection());
+    }
+
+    public function all(): array
+    {
+        $stmt = $this->connection->query('SELECT key, value FROM settings');
+        $settings = [];
+        foreach ($stmt->fetchAll() as $row) {
+            $settings[$row['key']] = $row['value'];
+        }
+
+        return $settings;
+    }
+
+    public function get(string $key, ?string $default = null): ?string
+    {
+        $stmt = $this->connection->prepare('SELECT value FROM settings WHERE key = :key');
+        $stmt->execute(['key' => $key]);
+        $value = $stmt->fetchColumn();
+
+        return $value !== false ? (string) $value : $default;
+    }
+
+    public function updateMany(array $settings): void
+    {
+        $stmt = $this->connection->prepare('REPLACE INTO settings (key, value) VALUES (:key, :value)');
+        foreach ($settings as $key => $value) {
+            $stmt->execute([
+                'key' => $key,
+                'value' => $value,
+            ]);
+        }
+    }
+}

--- a/src/Repositories/UserRepository.php
+++ b/src/Repositories/UserRepository.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repositories;
+
+use App\Core\Config;
+use App\Core\Database;
+use PDO;
+
+final class UserRepository
+{
+    public function __construct(private readonly PDO $connection)
+    {
+    }
+
+    public static function make(): self
+    {
+        return new self(Database::getInstance()->getConnection());
+    }
+
+    public function all(): array
+    {
+        $stmt = $this->connection->query('SELECT id, name, email, role, created_at, updated_at FROM users ORDER BY created_at DESC');
+        return $stmt->fetchAll();
+    }
+
+    public function findByEmail(string $email): ?array
+    {
+        $stmt = $this->connection->prepare('SELECT * FROM users WHERE email = :email');
+        $stmt->execute(['email' => $email]);
+        $result = $stmt->fetch();
+
+        return $result ?: null;
+    }
+
+    public function find(int $id): ?array
+    {
+        $stmt = $this->connection->prepare('SELECT * FROM users WHERE id = :id');
+        $stmt->execute(['id' => $id]);
+        $result = $stmt->fetch();
+
+        return $result ?: null;
+    }
+
+    public function save(array $data): void
+    {
+        $now = (new \DateTimeImmutable())->format(DATE_ATOM);
+        $payload = [
+            'name' => $data['name'],
+            'email' => $data['email'],
+            'role' => $data['role'],
+            'updated_at' => $now,
+        ];
+
+        if (!empty($data['password'])) {
+            $payload['password'] = password_hash($data['password'], Config::get('security.password_algo'));
+        }
+
+        if (isset($data['id'])) {
+            $payload['id'] = $data['id'];
+            $sql = 'UPDATE users SET name = :name, email = :email, role = :role, updated_at = :updated_at';
+            if (isset($payload['password'])) {
+                $sql .= ', password = :password';
+            }
+            $sql .= ' WHERE id = :id';
+            $this->connection->prepare($sql)->execute($payload);
+        } else {
+            $payload['password'] = $payload['password'] ?? password_hash($data['password'] ?? 'ChangeMe123!', Config::get('security.password_algo'));
+            $payload['created_at'] = $now;
+            $this->connection->prepare('INSERT INTO users (name, email, password, role, created_at, updated_at) VALUES (:name, :email, :password, :role, :created_at, :updated_at)')->execute($payload);
+        }
+    }
+
+    public function delete(int $id): void
+    {
+        $this->connection->prepare('DELETE FROM users WHERE id = :id')->execute(['id' => $id]);
+    }
+}

--- a/src/Services/AuthService.php
+++ b/src/Services/AuthService.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Repositories\UserRepository;
+
+final class AuthService
+{
+    public function __construct(private readonly UserRepository $users)
+    {
+    }
+
+    public static function make(): self
+    {
+        return new self(UserRepository::make());
+    }
+
+    public function attempt(string $email, string $password): bool
+    {
+        $user = $this->users->findByEmail($email);
+        if (!$user) {
+            return false;
+        }
+
+        if (!password_verify($password, $user['password'])) {
+            return false;
+        }
+
+        $_SESSION['user_id'] = $user['id'];
+        $_SESSION['user_role'] = $user['role'];
+
+        return true;
+    }
+
+    public function user(): ?array
+    {
+        if (!isset($_SESSION['user_id'])) {
+            return null;
+        }
+
+        return $this->users->find((int) $_SESSION['user_id']);
+    }
+
+    public function checkRole(string $role): bool
+    {
+        return isset($_SESSION['user_role']) && $_SESSION['user_role'] === $role;
+    }
+
+    public function logout(): void
+    {
+        session_destroy();
+    }
+}

--- a/src/Services/VersionManager.php
+++ b/src/Services/VersionManager.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Core\Database;
+use PDO;
+
+final class VersionManager
+{
+    private function __construct()
+    {
+    }
+
+    public static function initialize(Database $database): void
+    {
+        $connection = $database->getConnection();
+        $connection->exec('CREATE TABLE IF NOT EXISTS version_cache (
+            id INTEGER PRIMARY KEY CHECK (id = 1),
+            major INTEGER NOT NULL,
+            minor INTEGER NOT NULL,
+            patch INTEGER NOT NULL,
+            updated_at TEXT NOT NULL
+        )');
+
+        $count = (int) $connection->query('SELECT COUNT(*) FROM version_cache')->fetchColumn();
+        if ($count === 0) {
+            $latest = self::latestVersion($connection);
+            $stmt = $connection->prepare('INSERT INTO version_cache (id, major, minor, patch, updated_at) VALUES (1, :major, :minor, :patch, :updated_at)');
+            $stmt->execute([
+                'major' => $latest['major'],
+                'minor' => $latest['minor'],
+                'patch' => $latest['patch'],
+                'updated_at' => (new \DateTimeImmutable())->format(DATE_ATOM),
+            ]);
+        }
+    }
+
+    public static function latest(): string
+    {
+        $connection = Database::getInstance()->getConnection();
+        $stmt = $connection->query('SELECT major, minor, patch FROM version_cache WHERE id = 1');
+        $cache = $stmt->fetch();
+
+        if (!$cache) {
+            $latest = self::latestVersion($connection);
+            return sprintf('%d.%d.%d', $latest['major'], $latest['minor'], $latest['patch']);
+        }
+
+        return sprintf('%d.%d.%d', $cache['major'], $cache['minor'], $cache['patch']);
+    }
+
+    public static function record(string $note, string $type = 'patch'): void
+    {
+        $connection = Database::getInstance()->getConnection();
+        $latest = self::latestVersion($connection);
+
+        [$major, $minor, $patch] = [$latest['major'], $latest['minor'], $latest['patch']];
+
+        if ($type === 'major') {
+            $major += 1;
+            $minor = 0;
+            $patch = 0;
+        } elseif ($type === 'minor') {
+            $minor += 1;
+            $patch = 0;
+        } else {
+            $patch += 1;
+        }
+
+        $now = (new \DateTimeImmutable())->format(DATE_ATOM);
+        $stmt = $connection->prepare('INSERT INTO version_history (major, minor, patch, note, created_at) VALUES (:major, :minor, :patch, :note, :created_at)');
+        $stmt->execute([
+            'major' => $major,
+            'minor' => $minor,
+            'patch' => $patch,
+            'note' => $note,
+            'created_at' => $now,
+        ]);
+
+        $connection->prepare('REPLACE INTO version_cache (id, major, minor, patch, updated_at) VALUES (1, :major, :minor, :patch, :updated_at)')
+            ->execute([
+                'major' => $major,
+                'minor' => $minor,
+                'patch' => $patch,
+                'updated_at' => $now,
+            ]);
+    }
+
+    private static function latestVersion(PDO $connection): array
+    {
+        $stmt = $connection->query('SELECT major, minor, patch FROM version_history ORDER BY id DESC LIMIT 1');
+        $result = $stmt->fetch();
+
+        if (!$result) {
+            return ['major' => 0, 'minor' => 1, 'patch' => 0];
+        }
+
+        return $result;
+    }
+}

--- a/storage/templates/admin_layout.php
+++ b/storage/templates/admin_layout.php
@@ -1,0 +1,54 @@
+<?php
+use App\Services\VersionManager;
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Admin · <?= htmlspecialchars($settings['site_title'] ?? 'Dragon Reptiles CMS'); ?></title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;600;700&display=swap" rel="stylesheet">
+    <style>
+        body { font-family: 'Space Grotesk', sans-serif; background: #020617; color: #e2e8f0; }
+    </style>
+</head>
+<body class="min-h-screen flex">
+    <aside class="w-72 bg-slate-900/80 backdrop-blur border-r border-slate-800 hidden md:flex flex-col">
+        <div class="px-6 py-8 border-b border-slate-800">
+            <p class="text-xs uppercase tracking-widest text-slate-400">Dragon Reptiles CMS</p>
+            <h1 class="text-2xl font-semibold text-cyan-300">Adminbereich</h1>
+        </div>
+        <nav class="flex-1 px-4 py-6 space-y-2 text-sm">
+            <?php foreach ($navigation as $item): ?>
+                <a href="<?= htmlspecialchars($item['href']); ?>" class="block px-4 py-3 rounded-xl <?= $item['active'] ? 'bg-cyan-500/20 text-cyan-200' : 'hover:bg-slate-800/80'; ?>">
+                    <?= htmlspecialchars($item['label']); ?>
+                </a>
+            <?php endforeach; ?>
+        </nav>
+        <div class="px-6 py-6 border-t border-slate-800 text-xs text-slate-500">
+            Version <?= VersionManager::latest(); ?>
+        </div>
+    </aside>
+    <div class="flex-1 flex flex-col">
+        <header class="border-b border-slate-800 bg-slate-900/70 backdrop-blur px-6 py-4 flex items-center justify-between">
+            <div>
+                <h2 class="text-lg font-semibold"><?= htmlspecialchars($title ?? 'Übersicht'); ?></h2>
+                <p class="text-sm text-slate-400"><?= htmlspecialchars($subtitle ?? 'Verwalte Inhalte und Einstellungen.'); ?></p>
+            </div>
+            <div class="flex gap-3 text-sm">
+                <form method="post" action="/admin/logout.php">
+                    <button class="px-4 py-2 rounded-lg border border-slate-700 hover:border-rose-500 hover:text-rose-300" type="submit">Logout</button>
+                </form>
+            </div>
+        </header>
+        <main class="flex-1 p-6 bg-slate-950/60">
+            <div class="max-w-5xl mx-auto space-y-6">
+                <?= $content ?? ''; ?>
+            </div>
+        </main>
+    </div>
+</body>
+</html>

--- a/storage/templates/public_layout.php
+++ b/storage/templates/public_layout.php
@@ -1,0 +1,63 @@
+<?php
+use App\Services\VersionManager;
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title><?= htmlspecialchars($settings['site_title'] ?? 'Dragon Reptiles CMS'); ?></title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&display=swap" rel="stylesheet">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+        body { font-family: 'Montserrat', sans-serif; background: #050505; color: #f5f5f5; }
+        .gradient-border { position: relative; }
+        .gradient-border::before { content: ""; position: absolute; inset: -2px; background: linear-gradient(120deg, #22d3ee, #6366f1, #ec4899); z-index: -1; border-radius: inherit; filter: blur(6px); opacity: 0.6; }
+    </style>
+</head>
+<body class="min-h-screen flex flex-col">
+<header class="border-b border-slate-800 bg-slate-950/80 backdrop-blur">
+    <div class="max-w-6xl mx-auto px-6 py-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div>
+            <span class="text-xs uppercase tracking-widest text-slate-400"><?= htmlspecialchars($settings['logo_text'] ?? 'Dragon Reptiles'); ?></span>
+            <h1 class="text-3xl font-bold text-cyan-300 drop-shadow"><?= htmlspecialchars($settings['header_content'] ?? 'Dragon Reptiles CMS'); ?></h1>
+        </div>
+        <nav class="flex gap-4 text-sm">
+            <?php
+            try {
+                $menu = json_decode($settings['menu_structure'] ?? '[]', true, 512, JSON_THROW_ON_ERROR);
+            } catch (\JsonException) {
+                $menu = [];
+            }
+            ?>
+            <?php foreach ($menu as $item): ?>
+                <a class="px-4 py-2 rounded-full border border-slate-800 hover:border-cyan-400 transition" href="<?= htmlspecialchars($item['url']); ?>"><?= htmlspecialchars($item['label']); ?></a>
+            <?php endforeach; ?>
+        </nav>
+    </div>
+</header>
+<main class="flex-1">
+    <section class="max-w-6xl mx-auto px-6 py-10 grid gap-10 md:grid-cols-[2fr,1fr]">
+        <article class="space-y-6">
+            <?= $content ?? ''; ?>
+        </article>
+        <aside class="gradient-border rounded-3xl p-[1px]">
+            <div class="rounded-3xl bg-slate-900/60 p-6 space-y-6">
+                <h2 class="text-lg font-semibold text-slate-200">Insights</h2>
+                <div class="space-y-3 text-sm leading-relaxed text-slate-300">
+                    <?= $settings['sidebar_content'] ?? '<p>Modernste Informationen rund um Reptilienhaltung und -genetik.</p>'; ?>
+                </div>
+            </div>
+        </aside>
+    </section>
+</main>
+<footer class="border-t border-slate-800 bg-slate-950/90 backdrop-blur">
+    <div class="max-w-6xl mx-auto px-6 py-6 flex flex-col md:flex-row md:items-center md:justify-between text-sm text-slate-400">
+        <div><?= $settings['footer_content'] ?? '&copy; ' . date('Y') . ' Dragon Reptiles'; ?></div>
+        <div>Version <?= VersionManager::latest(); ?></div>
+    </div>
+</footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add bootstrap, configuration, and SQLite migrations including initial version tracking
- implement public layout with configurable navigation, homepage, page, and news views
- deliver secure admin area for settings, page, post, and user management with authentication

## Testing
- find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l

------
https://chatgpt.com/codex/tasks/task_e_68df1c9c5ef8832ba2585f938bbf637d